### PR TITLE
Fix Retrieve All Plans For Bamboo Enviroment

### DIFF
--- a/metrics-service/src/providers/bamboo/metrics/bamboo.builds.ts
+++ b/metrics-service/src/providers/bamboo/metrics/bamboo.builds.ts
@@ -33,8 +33,18 @@ export async function getPlans(listProjects:IBambooProject[],metadata: IBambooMe
       const projetData = getProject.data;
       logger.info(`Current project key: ${projetData.key}`);
 
+      const sizePlans = await getQuery({auth: { username: authUser, password: authPass }},
+        urlBambooProject.concat(`.json`))
+      .then((response) => {
+          return response;
+      });
+
+      const size = sizePlans.data.plans.size;
+
+      logger.info(`The size of all plans is ${size}`);
+
       const getPlans = await getQuery({auth: { username: authUser, password: authPass }},
-        urlBambooProject.concat(`.json?expand=plans`))
+        urlBambooProject.concat(`.json?expand=plans&max-result=${size}`))
       .then((response) => {
           return response;
       });

--- a/metrics-service/src/providers/bamboo/metrics/bamboo.releases.ts
+++ b/metrics-service/src/providers/bamboo/metrics/bamboo.releases.ts
@@ -17,6 +17,16 @@ export async function getPlanKey(url: string,authUser:string,authPass:string,lis
       logger.info(`validate project ${field.name} exist - Bamboo`);
       const urlBambooProject = url.concat(`/rest/api/latest/project/${field.name}`);
 
+      const sizePlans = await getQuery({auth: { username: authUser, password: authPass }},
+        urlBambooProject.concat(`.json`))
+      .then((response) => {
+          return response;
+      });
+
+      const size = sizePlans.data.plans.size;
+
+      logger.info(`The size of all plans is ${size}`);
+
       const getProject = await getQuery({auth: { username: authUser, password: authPass }}, urlBambooProject)
       .then((response) => { return response; });
       const statusResponse = getProject.status
@@ -29,7 +39,7 @@ export async function getPlanKey(url: string,authUser:string,authPass:string,lis
       logger.info(`Current project key: ${projetData.key}`);
 
       const getPlans = await getQuery({auth: { username: authUser, password: authPass }},
-        urlBambooProject.concat(`.json?expand=plans`))
+        urlBambooProject.concat(`.json?expand=plans&max-result=${size}`))
       .then((response) => {
           return response;
       });


### PR DESCRIPTION
I was having a problem using the bamboo provider as it wasn't returning all the plans from in my project.
The project inside bamboo contains 50 plans, but it was retrieving only 25. 
Then I was searching about the Bamboo API and I realized that the max-results of plans is 25 by default. So if you want a bigger size of plans, it must declared as query param.

For example: `/rest/api/latest/project/${PROJECT}.json?expand=plans&max-result=50`

**Case where has not the max-results param. The API will use 25 as default value**
![image](https://user-images.githubusercontent.com/20498649/136194599-24cbb266-8c99-4d77-b2da-f5af1d9682a9.png)


**Case where HAS the max-results param.**
![image](https://user-images.githubusercontent.com/20498649/136194723-c1696fbc-8dd7-429b-b2bc-44ccc521b6e5.png)


Contact: kevintoshihiro@ciandt.com
 